### PR TITLE
**fixed** WallabagServiceEntries.cs: http scheme was always replaced …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 **/.env
 .env
+compose/

--- a/src/Linkding/Program.cs
+++ b/src/Linkding/Program.cs
@@ -5,6 +5,14 @@ IHost host = Host.CreateDefaultBuilder(args)
     {
         services.Add_Linkding_HttpClient(ctx.Configuration);
         services.AddHostedService<Worker>();
+    }).ConfigureHostConfiguration((builder) =>
+    {
+        builder
+            .AddEnvironmentVariables()
+            .AddCommandLine(args)
+            .AddJsonFile("appsettings.json")
+            .AddJsonFile("appsettings.Development.json")
+            .AddUserSecrets<Program>(true);
     })
     .Build();
 

--- a/src/Services/Wallabag.Client/WallabagServiceEntries.cs
+++ b/src/Services/Wallabag.Client/WallabagServiceEntries.cs
@@ -26,7 +26,11 @@ public partial class WallabagService
                 while (allQuery.QueryLinks.Next != null && !string.IsNullOrEmpty(allQuery.QueryLinks.Next.Href))
                 {
                     // url = allQuery.QueryLinks.Next.Href.Replace(_settings.Url, "");
-                    url = allQuery.QueryLinks.Next.Href.Replace("http://", "https://");
+                    if (_client.BaseAddress.Scheme == "https")
+                    {
+                        url = allQuery.QueryLinks.Next.Href.Replace("http://", "https://");
+                    }
+
                     allQuery = await GetJsonAsync<WallabagQuery>(url);
                     bookmarks.AddRange(allQuery.Embedded.Items);
                 }

--- a/src/Wallabag/Handler/LinkdingBookmarkToWallabagHandler.cs
+++ b/src/Wallabag/Handler/LinkdingBookmarkToWallabagHandler.cs
@@ -60,7 +60,7 @@ namespace Wallabag.Handler
                             }
                         }
 
-                        if (addToWallabag && !updatedWallabags.ContainsKey(bookmark.Url))
+                        if (addToWallabag && !updatedWallabags.ContainsKey(cleanUrl))
                         {
                             updatedWallabags.Add(cleanUrl,
                                 bookmark.TagNames.Where(x => !x.Equals(tagName, StringComparison.OrdinalIgnoreCase)));

--- a/src/Wallabag/Program.cs
+++ b/src/Wallabag/Program.cs
@@ -7,6 +7,14 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.Add_Linkding_HttpClient(ctx.Configuration);
         services.Add_Wallabag_Worker(ctx.Configuration);
         services.AddHostedService<Worker>();
+    }).ConfigureHostConfiguration((builder) =>
+    {
+        builder
+            .AddEnvironmentVariables()
+            .AddCommandLine(args)
+            .AddJsonFile("appsettings.json")
+            .AddJsonFile("appsettings.Development.json")
+            .AddUserSecrets<Program>(true);
     })
     .Build();
 

--- a/src/Wallabag/Wallabag.csproj
+++ b/src/Wallabag/Wallabag.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="YamlDotNet" Version="12.3.1" />
     </ItemGroup>


### PR DESCRIPTION
…with https. Now the replacement is bound to a condition (if the base adr scheme == https, then replace the next page url (http) with https).